### PR TITLE
61 서버 api요청 시 에러 처리

### DIFF
--- a/front/lib/core/project/data/data_sources/remote_data_source.dart
+++ b/front/lib/core/project/data/data_sources/remote_data_source.dart
@@ -31,7 +31,7 @@ class ProjectRemoteDataSourceImpl implements ProjectRemoteDataSource {
         throw ServerException();
       }
     } on DioException {
-      throw ServerException();
+      rethrow;
     }
   }
 
@@ -46,7 +46,7 @@ class ProjectRemoteDataSourceImpl implements ProjectRemoteDataSource {
         throw ServerException();
       }
     } on DioException {
-      throw ServerException();
+      rethrow;
     }
   }
 
@@ -62,7 +62,7 @@ class ProjectRemoteDataSourceImpl implements ProjectRemoteDataSource {
         throw ServerException();
       }
     } on DioException {
-      throw ServerException();
+      rethrow;
     }
   }
 
@@ -77,7 +77,7 @@ class ProjectRemoteDataSourceImpl implements ProjectRemoteDataSource {
         throw ServerException();
       }
     } on DioException {
-      throw ServerException();
+      rethrow;
     }
   }
 
@@ -93,8 +93,8 @@ class ProjectRemoteDataSourceImpl implements ProjectRemoteDataSource {
       } else {
         throw ServerException();
       }
-    }  on DioException {
-      throw ServerException();
+    } on DioException {
+      rethrow;
     }
   }
 }

--- a/front/lib/core/utils/failure.dart
+++ b/front/lib/core/utils/failure.dart
@@ -1,8 +1,12 @@
 import 'package:equatable/equatable.dart';
 
-abstract class Failure extends Equatable {
+class Failure extends Equatable {
   const Failure(this.message);
   final String message;
+
+  Failure copyWith({String? message}) {
+    return Failure(message ?? this.message);
+  }
 
   @override
   List<Object> get props => [message];
@@ -18,4 +22,56 @@ class ConnectionFailure extends Failure {
 
 class DatabaseFailure extends Failure {
   const DatabaseFailure(String message) : super(message);
+}
+
+enum ResponseFailure {
+  badRequest(
+      code: 400, message: 'badRequest', failure: ServerFailure('badRequest')),
+  forbidden(
+      code: 403, message: 'forbidden', failure: ServerFailure('forbidden')),
+  unauthorized(
+      code: 401,
+      message: 'unauthorized',
+      failure: ServerFailure('unauthorized')),
+  notFound(code: 404, message: 'notFound', failure: ServerFailure('notFound')),
+
+  cancel(code: 701, message: 'cancel', failure: ServerFailure('cancel')),
+  connectionError(
+      code: 702,
+      message: 'connectionError',
+      failure: ServerFailure('connectionError')),
+  connectionTimeout(
+      code: 703,
+      message: 'connectionTimeout',
+      failure: ServerFailure('connectionTimeout')),
+  receiveTimeout(
+      code: 704,
+      message: 'receiveTimeout',
+      failure: ServerFailure('receiveTimeout')),
+  sendTimeout(
+      code: 705, message: 'sendTimeout', failure: ServerFailure('sendTimeout')),
+  unknown(code: 706, message: 'unknown', failure: ServerFailure('unknown'));
+
+  factory ResponseFailure.getByCode(int code) {
+    return ResponseFailure.values.firstWhere((value) => value.code == code,
+        orElse: () => ResponseFailure.unknown);
+  }
+
+  const ResponseFailure(
+      {required this.code, required this.message, required this.failure});
+
+  final int code;
+  final String message;
+  final Failure failure;
+  Failure getFailure() {
+    return ServerFailure(message);
+  }
+}
+
+enum ResponseSuccess {
+  success(200),
+  created(201);
+
+  const ResponseSuccess(this.code);
+  final int code;
 }

--- a/front/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/front/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,6 +5,8 @@
 import FlutterMacOS
 import Foundation
 
+import shared_preferences_foundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
 }

--- a/front/test/core/project/data/data_source/remote_data_source_test.dart
+++ b/front/test/core/project/data/data_source/remote_data_source_test.dart
@@ -4,7 +4,6 @@ import 'package:front/core/config/providers/dio.dart';
 import 'package:front/core/project/data/data_sources/remote_data_source.dart';
 import 'package:front/core/project/data/models/project.dart';
 import 'package:front/core/project/data/models/project_request.dart';
-import 'package:front/core/utils/exception.dart';
 import 'package:http_mock_adapter/http_mock_adapter.dart';
 import '../../../../helpers/dummy_data/project/api_response.dart';
 import '../../../../helpers/provider_container.dart';
@@ -63,7 +62,7 @@ void main() {
           '/v1/projects/$teamId', (server) => server.reply(500, null));
 
       expect(projectRemoteDataSource.getProjectsByTeamId(teamId),
-          throwsA(isA<ServerException>()));
+          throwsA(isA<DioException>()));
     });
   });
 
@@ -86,7 +85,7 @@ void main() {
           '/v1/project/$projectId', (server) => server.reply(500, null));
 
       expect(projectRemoteDataSource.getProjectsByTeamId(projectId),
-          throwsA(isA<ServerException>()));
+          throwsA(isA<DioException>()));
     });
   });
 
@@ -115,7 +114,7 @@ void main() {
       expect(
           projectRemoteDataSource.updateProjectById(
               projectRequestModel, projectId),
-          throwsA(isA<ServerException>()));
+          throwsA(isA<DioException>()));
     });
   });
 
@@ -139,7 +138,7 @@ void main() {
           '/v1/project/$projectId', (server) => server.reply(500, null));
 
       expect(projectRemoteDataSource.deleteProjectById(projectId),
-          throwsA(isA<ServerException>()));
+          throwsA(isA<DioException>()));
     });
   });
 }


### PR DESCRIPTION
## 요약

- [feat: create ResponseFailure enum]
- [feat: create ErrorHandler mixin]
- [feat: apply ErrorHandler mixin to ProjectRepository]
- [fix: change remoteDataSource to rethrow DioException]

## 이슈 번호

- #61 
 
## 작업 내용

- repository의 예외처리를 ErrorHandler mixin을 사용해서 한 번에 관리할 수 있도록 했습니다. 
- ResponseFailure enum을 만들어 에러 코드별 기본 에러 메시지를 관리 할 수 있도록 했습니다.


- 고민해볼 사항이 있다면 적어주세요